### PR TITLE
Primクラスの実装

### DIFF
--- a/lib/Graph/prim.cpp
+++ b/lib/Graph/prim.cpp
@@ -19,7 +19,7 @@ class Prim {
   vector<bool> used;
 
  public:
-  Prim(int n);
+  explicit Prim(int n);
   void AddEdge(int from, int to, T cost);
   T Run();
 };

--- a/lib/Graph/prim.cpp
+++ b/lib/Graph/prim.cpp
@@ -3,7 +3,7 @@
 template <typename T>
 class Prim {
  private:
-  WeightedGraph<T> graph;
+  AdjList<T> graph;
   vector<bool> used;
 
  public:

--- a/lib/Graph/prim.cpp
+++ b/lib/Graph/prim.cpp
@@ -1,17 +1,5 @@
 #include "template.h"
-
-template <typename T>
-struct Edge {
-  int to;
-  T cost;
-  Edge(int to, T cost) : to(to), cost(cost) {}
-};
-
-template <typename T>
-using Edges = vector<Edge<T>>;
-template <typename T>
-using WeightedGraph = vector<Edges<T>>;
-
+#include "graph.h"
 template <typename T>
 class Prim {
  private:

--- a/lib/Graph/prim.cpp
+++ b/lib/Graph/prim.cpp
@@ -1,0 +1,47 @@
+#include "template.h"
+
+template <typename T>
+struct Edge {
+  int to;
+  T cost;
+  Edge(int to, T cost) : to(to), cost(cost) {}
+};
+
+template <typename T>
+class Prim {
+ private:
+  vector<vector<Edge<T>>> graph;
+  vector<bool> used;
+
+ public:
+  Prim(int n);
+  void AddEdge(int from, int to, T cost);
+  T Run();
+};
+
+template <typename T>
+Prim<T>::Prim(int n) : graph(n), used(n, false) {}
+
+template <typename T>
+void Prim<T>::AddEdge(int from, int to, T cost) {
+  graph[from].push_back(Edge<T>(to, cost));
+}
+
+template <typename T>
+T Prim<T>::Run() {
+  using Pi = pair<T, int>;
+  T total = 0;
+  priority_queue<Pi, vector<Pi>, greater<Pi>> que;
+  que.emplace(0, 0);
+  while (!que.empty()) {
+    Pi p = que.top();
+    que.pop();
+    if (used[p.second]) continue;
+    used[p.second] = true;
+    total += p.first;
+    for (auto &e : graph[p.second]) {
+      que.emplace(e.cost, e.to);
+    }
+  }
+  return total;
+}

--- a/lib/Graph/prim.cpp
+++ b/lib/Graph/prim.cpp
@@ -8,9 +8,14 @@ struct Edge {
 };
 
 template <typename T>
+using Edges = vector<Edge<T>>;
+template <typename T>
+using WeightedGraph = vector<Edges<T>>;
+
+template <typename T>
 class Prim {
  private:
-  vector<vector<Edge<T>>> graph;
+  WeightedGraph<T> graph;
   vector<bool> used;
 
  public:


### PR DESCRIPTION
最小全域木の全体のコストを返します．最小全域木自体は作りません．